### PR TITLE
The Orocos member master_project is obsolete

### DIFF
--- a/lib/log_tools/converter.rb
+++ b/lib/log_tools/converter.rb
@@ -115,7 +115,7 @@ module LogTools
         end
 
         def normalize_name(name)
-            if(name_m = Orocos.master_project.intermediate_type_for(name))
+            if(Orocos.default_loader.resolve_type(name) && name_m = Orocos.default_loader.intermediate_type_for(name))
                Converter.info "#{name} is an intermedia type called #{name_m}"
                name_m.name
             else


### PR DESCRIPTION
rock-convert does not work on master currently, since it trys to access the member master_project in Orocos which was removed. I'm not sure if it is correct to use default_loader instead.
I also had to add a check if the type could be resolved first, since Orocos.default_loader.intermediate_type_for does raise an ArgumentError instead of a Typelib::NotFound.
